### PR TITLE
Lisätty UTF-8 filtteri

### DIFF
--- a/d14-spring_mvc/src/main/webapp/WEB-INF/web.xml
+++ b/d14-spring_mvc/src/main/webapp/WEB-INF/web.xml
@@ -15,4 +15,25 @@
 		org.springframework.web.context.ContextLoaderListener 
 	</listener-class> 
   </listener>
+  
+    <!-- force post-method to use UTF-8 encoding -->
+  <filter>
+     <filter-name>encoding-filter</filter-name>
+     <filter-class>org.springframework.web.filter.CharacterEncodingFilter</filter-class>
+     <init-param>
+	    <param-name>encoding</param-name>
+	    <param-value>UTF-8</param-value>
+     </init-param>
+     
+	 <init-param>
+	     <param-name>forceEncoding</param-name>
+	     <param-value>true</param-value>
+     </init-param>
+  </filter>
+
+   <filter-mapping>
+       <filter-name>encoding-filter</filter-name>
+       <url-pattern>/*</url-pattern>
+   </filter-mapping>
+   
 </web-app>


### PR DESCRIPTION
Filtteri pakottaa POST-metodin käyttämään UTF-8:aa. Ääkköset tallentuvat myös tietokantaan oikein tämän jälkeen.
